### PR TITLE
Add FlagOS support

### DIFF
--- a/vllm/model_executor/models/minicpmo.py
+++ b/vllm/model_executor/models/minicpmo.py
@@ -28,6 +28,7 @@ from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Annotated, Any, Literal, TypeAlias
 
 import torch
+import os
 from torch import nn
 from transformers import BatchFeature
 from transformers.modeling_outputs import BaseModelOutputWithPast
@@ -76,7 +77,13 @@ from .utils import AutoWeightsLoader, cast_overflow_tensors, maybe_prefix
 
 CPU_DEVICE = torch.device("cpu")
 
+if os.getenv("USE_FLAGOS") == "1":
+    import flag_gems
 
+    FlagGemsConfig=["sort", "sort_stable", "layer_norm", "clamp_", "cos", "embedding", "exp", "exponential_", "full", "gather", "gelu", "index", "le", "lt", "lt_scalar", "masked_fill_", "max", "ones", "pow_scalar", "prod_dim", "rand_like", "reciprocal", "repeat", "scatter", "scatter_", "sin", "sub", "true_divide", "true_divide_", "uniform_", "where_scalar_self", "where_self_out", "zeros", "zeros_like"]
+
+    flag_gems.only_enable(record=False, include=FlagGemsConfig)
+    
 class MiniCPMOAudioFeatureInputs(TensorSchema):
     """
     Dimensions:


### PR DESCRIPTION
## Description
This PR adds FlagOS support to the MiniCPMO model file, controlled by the `USE_FLAGOS` environment variable. With FlagOS enabled, it achieves a **0.998–1.028× throughput** improvement compared to the CUDA version.

## Usage
### Enable FlagOS (disabled by default)
Set `USE_FLAGOS=1` when running the inference program. For example:

```bash
USE_FLAGOS=1 vllm serve ${model_path} --dtype auto --gpu_memory_utilization 0.9 --trust-remote-code --max-num-batched-tokens 2048 --served-model-name cpmo --port ${Port}