### PR TITLE
Improve the maintainability of the code

### DIFF
--- a/vllm/model_executor/models/minicpmo.py
+++ b/vllm/model_executor/models/minicpmo.py
@@ -75,10 +75,13 @@ from .utils import AutoWeightsLoader, cast_overflow_tensors, maybe_prefix
 
 CPU_DEVICE = torch.device("cpu")
 
-if os.getenv("USE_FLAGOS") == "1":
+try:
     import flag_gems
+except ImportError:
+    flag_gems = None
 
-    FlagGemsConfig = [
+if flag_gems and os.getenv("USE_FLAGOS") == "1":
+    FLAG_GEMS_CONFIG = [
         "sort", "sort_stable", "layer_norm", "clamp_", "cos", "embedding",
         "exp", "exponential_", "full", "gather", "gelu", "index", "le", "lt",
         "lt_scalar", "masked_fill_", "max", "ones", "pow_scalar", "prod_dim",
@@ -86,8 +89,7 @@ if os.getenv("USE_FLAGOS") == "1":
         "sub", "true_divide", "true_divide_", "uniform_", "where_scalar_self",
         "where_self_out", "zeros", "zeros_like"
     ]
-
-    flag_gems.only_enable(record=False, include=FlagGemsConfig)
+    flag_gems.only_enable(record=False, include=FLAG_GEMS_CONFIG)
 
 
 class MiniCPMOAudioFeatureInputs(TensorSchema):

--- a/vllm/model_executor/models/minicpmo.py
+++ b/vllm/model_executor/models/minicpmo.py
@@ -24,9 +24,10 @@
 # limitations under the License.
 """Inference-only MiniCPM-O model compatible with HuggingFace weights."""
 
+import os
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Annotated, Any, Literal, TypeAlias
-import os
+
 import torch
 from torch import nn
 from transformers import BatchFeature
@@ -73,21 +74,49 @@ from .minicpmv import (
 )
 from .utils import AutoWeightsLoader, cast_overflow_tensors, maybe_prefix
 
-CPU_DEVICE = torch.device("cpu")
-
 try:
     import flag_gems
 except ImportError:
     flag_gems = None
 
+CPU_DEVICE = torch.device("cpu")
+
 if flag_gems and os.getenv("USE_FLAGOS") == "1":
     FLAG_GEMS_CONFIG = [
-        "sort", "sort_stable", "layer_norm", "clamp_", "cos", "embedding",
-        "exp", "exponential_", "full", "gather", "gelu", "index", "le", "lt",
-        "lt_scalar", "masked_fill_", "max", "ones", "pow_scalar", "prod_dim",
-        "rand_like", "reciprocal", "repeat", "scatter", "scatter_", "sin",
-        "sub", "true_divide", "true_divide_", "uniform_", "where_scalar_self",
-        "where_self_out", "zeros", "zeros_like"
+        "sort",
+        "sort_stable",
+        "layer_norm",
+        "clamp_",
+        "cos",
+        "embedding",
+        "exp",
+        "exponential_",
+        "full",
+        "gather",
+        "gelu",
+        "index",
+        "le",
+        "lt",
+        "lt_scalar",
+        "masked_fill_",
+        "max",
+        "ones",
+        "pow_scalar",
+        "prod_dim",
+        "rand_like",
+        "reciprocal",
+        "repeat",
+        "scatter",
+        "scatter_",
+        "sin",
+        "sub",
+        "true_divide",
+        "true_divide_",
+        "uniform_",
+        "where_scalar_self",
+        "where_self_out",
+        "zeros",
+        "zeros_like",
     ]
     flag_gems.only_enable(record=False, include=FLAG_GEMS_CONFIG)
 


### PR DESCRIPTION
Refactor the conditional import to follow PEP 8 guidelines for better code clarity and to rename a constant to adhere to standard naming conventions.
